### PR TITLE
Add internalConsoleOptions: neverOpen

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,7 @@
             "args": [],
             "cwd": "${workspaceFolder}/unit02-hilo",
             "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
             "stopAtEntry": false
         },
         {
@@ -21,6 +22,7 @@
             "args": [],
             "cwd": "${workspaceFolder}/unit03-jumper",
             "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
             "stopAtEntry": false
         },
         {
@@ -32,6 +34,7 @@
             "args": [],
             "cwd": "${workspaceFolder}/unit04-greed",
             "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
             "stopAtEntry": false
         },
         {
@@ -43,6 +46,7 @@
             "args": [],
             "cwd": "${workspaceFolder}/unit05-cycle",
             "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
             "stopAtEntry": false
         },
         {
@@ -54,6 +58,7 @@
             "args": [],
             "cwd": "${workspaceFolder}/unit06-game",
             "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
             "stopAtEntry": false
         }
     ]


### PR DESCRIPTION
Added "internalConsoleOptions": "neverOpen" to make it so that the default foreground tab is the terminal tab.